### PR TITLE
docu: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alternatively, if you have [go][] installed, you may install `cheat` using `go
 get`:
 
 ```sh
-go get -u github.com/cheat/cheat/cmd/cheat
+go install github.com/cheat/cheat/cmd/cheat@lastest
 ```
 
 Configuring


### PR DESCRIPTION
This is due to [go get deprecation](https://golang.org/doc/go-get-install-deprecation)

'go get' is no longer supported outside a module.